### PR TITLE
Updates the Curve Edit Plugin to work with Godot 4+

### DIFF
--- a/addons/curve_edit/path_edit.gd
+++ b/addons/curve_edit/path_edit.gd
@@ -6,7 +6,7 @@ var panel_instance
 
 func _can_handle(object) -> bool:
 	# Only paths are supported.
-	return object is Path3D or object is Path2D
+	return object is Path3D  # TODO: or object is Path2D
 
 
 ## Add the custom draw under the object-level transform panel.

--- a/addons/curve_edit/path_edit.gd
+++ b/addons/curve_edit/path_edit.gd
@@ -4,16 +4,16 @@ const TransformPanel = preload("res://addons/curve_edit/transform_panel.tscn")
 var panel_instance
 
 
-func can_handle(object):
+func _can_handle(object) -> bool:
 	# Only paths are supported.
-	return object is Path or object is Path2D
+	return object is Path3D or object is Path2D
 
 
 ## Add the custom draw under the object-level transform panel.
-func parse_property(object, type, path, hint, hint_text, usage):
-	# print(path, usage)
-	if path == "translation": # Place directly after the obj-scale transform
-		panel_instance = TransformPanel.instance()
+func _parse_property(object, type, name, hint_type, hint_string, usage_flags, wide) -> bool:
+	#print("Name: ", name, " | Usage flags: ", usage_flags, " | Hint Type: ", hint_type, " | Hint String: ", hint_string, " | Usage Flags: ", usage_flags)
+	if name == "position": # Place directly after the obj-scale transform
+		panel_instance = TransformPanel.instantiate()
 		add_custom_control(panel_instance)
 		panel_instance.call_deferred("update_current_transform", object)
 	return false

--- a/addons/curve_edit/path_edit.gd.uid
+++ b/addons/curve_edit/path_edit.gd.uid
@@ -1,0 +1,1 @@
+uid://drha37v06hmco

--- a/addons/curve_edit/plugin.gd
+++ b/addons/curve_edit/plugin.gd
@@ -1,17 +1,20 @@
-tool
+@tool
 extends EditorPlugin
 
 
-var plugin
+var plugin : EditorInspectorPlugin
 
 
 func _enter_tree():
+	print("Curve Edit: enter tree")
 	plugin = preload("res://addons/curve_edit/path_edit.gd").new()
 	add_inspector_plugin(plugin)
 
 
 func _exit_tree():
-	remove_inspector_plugin(plugin)
+	print("Curve Edit: exit tree")
+	if plugin != null:
+		remove_inspector_plugin(plugin)
 
 
 func refresh() -> void:

--- a/addons/curve_edit/plugin.gd
+++ b/addons/curve_edit/plugin.gd
@@ -6,13 +6,11 @@ var plugin : EditorInspectorPlugin
 
 
 func _enter_tree():
-	print("Curve Edit: enter tree")
 	plugin = preload("res://addons/curve_edit/path_edit.gd").new()
 	add_inspector_plugin(plugin)
 
 
 func _exit_tree():
-	print("Curve Edit: exit tree")
 	if plugin != null:
 		remove_inspector_plugin(plugin)
 

--- a/addons/curve_edit/plugin.gd.uid
+++ b/addons/curve_edit/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://bbk5dbfsf644n

--- a/addons/curve_edit/transform_panel.gd
+++ b/addons/curve_edit/transform_panel.gd
@@ -33,7 +33,6 @@ func _input(event):
 		return
 	if not event.keycode == KEY_ENTER:
 		return
-	#var focus = get_focus_owner()
 	var focus = get_viewport().gui_get_focus_owner()
 	if focus == edit_x or focus == edit_y or focus == edit_z:
 		_on_edit_focus_exited()

--- a/addons/curve_edit/transform_panel.gd
+++ b/addons/curve_edit/transform_panel.gd
@@ -1,5 +1,5 @@
 # Panel which is added to UI and used to trigger callbacks to update paths.
-tool
+@tool
 extends VBoxContainer
 
 # Index aliases
@@ -7,13 +7,13 @@ const POS = 0;
 const IN = 1;
 const OUT = 2;
 
-onready var point_index:OptionButton = get_node("HBoxContainer2/point_selector")
-onready var point_part:OptionButton = get_node("HBoxContainer2/point_part")
-onready var edit_x:LineEdit = get_node("HBoxContainer/x_edit")
-onready var edit_y:LineEdit = get_node("HBoxContainer/y_edit")
-onready var edit_z:LineEdit = get_node("HBoxContainer/z_edit")
+@onready var point_index:OptionButton = get_node("HBoxContainer2/point_selector")
+@onready var point_part:OptionButton = get_node("HBoxContainer2/point_part")
+@onready var edit_x:LineEdit = get_node("HBoxContainer/x_edit")
+@onready var edit_y:LineEdit = get_node("HBoxContainer/y_edit")
+@onready var edit_z:LineEdit = get_node("HBoxContainer/z_edit")
 
-var current_path:Path
+var current_path:Path3D
 var backup_curve:Curve3D
 var backup_path:WeakRef
 
@@ -31,9 +31,10 @@ func _ready():
 func _input(event):
 	if not (event is InputEventKey and event.pressed):
 		return
-	if not event.scancode == KEY_ENTER:
+	if not event.keycode == KEY_ENTER:
 		return
-	var focus = get_focus_owner()
+	#var focus = get_focus_owner()
+	var focus = get_viewport().gui_get_focus_owner()
 	if focus == edit_x or focus == edit_y or focus == edit_z:
 		_on_edit_focus_exited()
 		print("Pressed enter")
@@ -43,9 +44,9 @@ func _input(event):
 # for when the curve is modified externally.
 func update_current_transform(object):
 	if current_path and current_path != object:
-		current_path.disconnect("curve_changed", self, "_on_point_selector_item_selected")
+		current_path.disconnect("curve_changed", _on_point_selector_item_selected)
 	current_path = object
-	current_path.connect("curve_changed", self, "_on_point_selector_item_selected")
+	current_path.connect("curve_changed", _on_point_selector_item_selected)
 	if not current_path:
 		return
 	if not current_path.curve:
@@ -62,11 +63,13 @@ func update_current_transform(object):
 
 
 # Propogate an edit from the panel over to the curve itself.
+# Round the float to only have 2 decimal points 
 func update_path_point():
 	var loc = Vector3(
-		float(edit_x.text),
-		float(edit_y.text),
-		float(edit_z.text))
+		snapped(float(edit_x.text), 0.01),
+		snapped(float(edit_y.text), 0.01),
+		snapped(float(edit_z.text), 0.01)
+	)
 
 	var index = point_index.selected
 	if point_part.selected == POS:
@@ -95,14 +98,20 @@ func _on_edit_focus_exited():
 
 
 func _enforce_numeric_values(new_text:String, line_edit:LineEdit):
-	var init_cursor_pos = line_edit.caret_position
+	var init_cursor_pos = line_edit.caret_column
 	var compiled = ''
 	var regex = RegEx.new()
 	regex.compile("[-+]?[0-9]*\\.?[0-9]+")
 	for valid_character in regex.search_all(str(new_text)):
 		compiled += valid_character.get_string()
+	
+	# Round the float to only have 2 decimal points 
+	var point_pos : float = snapped(float(compiled), 0.01)
+	
+	compiled = str(point_pos)
+	
 	line_edit.set_text(compiled)
-	line_edit.caret_position = init_cursor_pos
+	line_edit.caret_column = init_cursor_pos
 
 
 # When the option dropdown is modified. No actual curve changes to apply.
@@ -166,15 +175,15 @@ func _on_z_edit_focus_entered():
 
 
 func _on_x_edit_gui_input(event):
-	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		edit_x.select_all()
 
 
 func _on_y_edit_gui_input(event):
-	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		edit_y.select_all()
 
 
 func _on_z_edit_gui_input(event):
-	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		edit_z.select_all()

--- a/addons/curve_edit/transform_panel.gd
+++ b/addons/curve_edit/transform_panel.gd
@@ -51,11 +51,7 @@ func update_current_transform(object):
 	if not current_path.curve:
 		return
 
-	var num_points = current_path.curve.get_point_count()
-
-	point_index.clear()
-	for i in range(num_points):
-		point_index.add_item("Point %s" % i)
+	populate_point_index_ui()
 
 	# Update UI box, which will also create/update the backup_curve.
 	_on_edit_focus_exited()
@@ -115,6 +111,9 @@ func _enforce_numeric_values(new_text:String, line_edit:LineEdit):
 
 # When the option dropdown is modified. No actual curve changes to apply.
 func _on_point_selector_item_selected(_index=0):
+
+	populate_point_index_ui()
+
 	if not current_path:
 		return
 	if not current_path.curve:
@@ -160,6 +159,12 @@ func _on_point_selector_item_selected(_index=0):
 	backup_curve = current_path.curve.duplicate()
 	backup_path = weakref(current_path)
 
+
+func populate_point_index_ui():
+	var num_points := current_path.curve.get_point_count()
+	point_index.clear()
+	for i in range(num_points):
+		point_index.add_item("Point %s" % i)
 
 func _on_x_edit_focus_entered():
 	edit_x.select_all()

--- a/addons/curve_edit/transform_panel.gd.uid
+++ b/addons/curve_edit/transform_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://cy88vbye2onga

--- a/addons/curve_edit/transform_panel.tscn
+++ b/addons/curve_edit/transform_panel.tscn
@@ -1,128 +1,102 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene format=3 uid="uid://bswoogmfwmnyr"]
 
-[ext_resource path="res://addons/curve_edit/transform_panel.gd" type="Script" id=1]
+[ext_resource type="Script" uid="uid://cy88vbye2onga" path="res://addons/curve_edit/transform_panel.gd" id="1"]
 
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="StyleBoxFlat" id="1"]
 content_margin_left = 10.0
 content_margin_top = 7.0
 content_margin_bottom = 7.0
-bg_color = Color( 0.12549, 0.145098, 0.192157, 1 )
+bg_color = Color(0.12549, 0.145098, 0.192157, 1)
 
-[sub_resource type="StyleBoxFlat" id=3]
+[sub_resource type="StyleBoxFlat" id="3"]
 content_margin_left = 12.0
+content_margin_top = 7.0
 content_margin_right = 4.0
-content_margin_top = 7.0
 content_margin_bottom = 7.0
-bg_color = Color( 0.12549, 0.145098, 0.192157, 1 )
+bg_color = Color(0.12549, 0.145098, 0.192157, 1)
 
-[sub_resource type="Theme" id=2]
+[sub_resource type="Theme" id="2"]
 LineEdit/constants/minimum_spaces = 16
-LineEdit/styles/normal = SubResource( 1 )
-OptionButton/styles/hover = SubResource( 3 )
-OptionButton/styles/normal = SubResource( 3 )
+LineEdit/styles/normal = SubResource("1")
+OptionButton/styles/hover = SubResource("3")
+OptionButton/styles/normal = SubResource("3")
 
-[sub_resource type="StyleBoxFlat" id=4]
+[sub_resource type="StyleBoxFlat" id="4"]
 content_margin_left = 10.0
-content_margin_right = 10.0
 content_margin_top = 7.0
+content_margin_right = 10.0
 content_margin_bottom = 7.0
-bg_color = Color( 0.0980392, 0.113725, 0.156863, 1 )
+bg_color = Color(0.0980392, 0.113725, 0.156863, 1)
 expand_margin_right = 10.0
 
-[sub_resource type="Theme" id=5]
-Label/colors/font_color = Color( 0.701961, 0.6, 0.243137, 1 )
-Label/styles/normal = SubResource( 4 )
+[sub_resource type="Theme" id="5"]
+Label/colors/font_color = Color(0.701961, 0.6, 0.243137, 1)
+Label/styles/normal = SubResource("4")
 
-[node name="TransformPanel" type="VBoxContainer"]
+[node name="TransformPanel" type="VBoxContainer" unique_id=1631313472]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-theme = SubResource( 2 )
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+theme = SubResource("2")
+script = ExtResource("1")
 
-[node name="Label" type="Label" parent="."]
-margin_right = 1024.0
-margin_bottom = 14.0
+[node name="Label" type="Label" parent="." unique_id=1570118104]
+layout_mode = 2
 size_flags_horizontal = 3
 text = "Edit curve point"
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="."]
-margin_top = 18.0
-margin_right = 1024.0
-margin_bottom = 46.0
+[node name="HBoxContainer2" type="HBoxContainer" parent="." unique_id=482845589]
+layout_mode = 2
 
-[node name="point_selector" type="OptionButton" parent="HBoxContainer2"]
-margin_right = 510.0
-margin_bottom = 28.0
+[node name="point_selector" type="OptionButton" parent="HBoxContainer2" unique_id=371069796]
+layout_mode = 2
 size_flags_horizontal = 3
-text = "0"
 
-[node name="point_part" type="OptionButton" parent="HBoxContainer2"]
-margin_left = 514.0
-margin_right = 1024.0
-margin_bottom = 28.0
+[node name="point_part" type="OptionButton" parent="HBoxContainer2" unique_id=190665583]
+layout_mode = 2
 size_flags_horizontal = 3
-text = "Position"
-items = [ "Position", null, false, 0, null, "In", null, false, 1, null, "Out", null, false, 2, null ]
 selected = 0
+item_count = 3
+popup/item_0/text = "Position"
+popup/item_0/id = 0
+popup/item_1/text = "In"
+popup/item_1/id = 1
+popup/item_2/text = "Out"
+popup/item_2/id = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
-margin_top = 50.0
-margin_right = 1024.0
-margin_bottom = 78.0
-theme = SubResource( 5 )
-custom_constants/separation = 0
+[node name="HBoxContainer" type="HBoxContainer" parent="." unique_id=1493861748]
+layout_mode = 2
+theme = SubResource("5")
 
-[node name="x" type="Label" parent="HBoxContainer"]
-margin_right = 27.0
-margin_bottom = 28.0
+[node name="x" type="Label" parent="HBoxContainer" unique_id=1820739900]
+layout_mode = 2
 text = "x"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="x_edit" type="LineEdit" parent="HBoxContainer"]
-margin_left = 27.0
-margin_right = 341.0
-margin_bottom = 28.0
+[node name="x_edit" type="LineEdit" parent="HBoxContainer" unique_id=1806955546]
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="y" type="Label" parent="HBoxContainer"]
-margin_left = 341.0
-margin_right = 368.0
-margin_bottom = 28.0
+[node name="y" type="Label" parent="HBoxContainer" unique_id=294015427]
+layout_mode = 2
 text = "y"
 
-[node name="y_edit" type="LineEdit" parent="HBoxContainer"]
-margin_left = 368.0
-margin_right = 682.0
-margin_bottom = 28.0
+[node name="y_edit" type="LineEdit" parent="HBoxContainer" unique_id=841302380]
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="z" type="Label" parent="HBoxContainer"]
-margin_left = 682.0
-margin_right = 709.0
-margin_bottom = 28.0
+[node name="z" type="Label" parent="HBoxContainer" unique_id=1305024345]
+layout_mode = 2
 text = "z"
 
-[node name="z_edit" type="LineEdit" parent="HBoxContainer"]
-margin_left = 709.0
-margin_right = 1024.0
-margin_bottom = 28.0
+[node name="z_edit" type="LineEdit" parent="HBoxContainer" unique_id=1067417393]
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Panel" type="Panel" parent="HBoxContainer"]
-margin_left = 1024.0
-margin_right = 1024.0
-margin_bottom = 28.0
+[node name="Panel" type="Panel" parent="HBoxContainer" unique_id=662034037]
+layout_mode = 2
 
-[node name="HSeparator" type="HSeparator" parent="."]
-margin_top = 82.0
-margin_right = 1024.0
-margin_bottom = 97.0
-rect_min_size = Vector2( 0, 15 )
+[node name="HSeparator" type="HSeparator" parent="." unique_id=1724696996]
+layout_mode = 2
 
 [connection signal="item_selected" from="HBoxContainer2/point_selector" to="." method="_on_point_selector_item_selected"]
 [connection signal="item_selected" from="HBoxContainer2/point_part" to="." method="_on_point_selector_item_selected"]


### PR DESCRIPTION
- Changes various out of date variables and functions so that this plugin works with Godot 4+
- Makes editing points a little easier by limiting how many decimal points are displayed in each input field in the UI
- Tested with Godot version 4.6.3

**Note:** The input text fields for the plugin are still a bit difficult to use as when you try to select text, it often fails or selects other input fields. This could be fixed in a future PR to improve usability.

I've also noticed that once in a while the plugin UI just simply fails to show the most recently changed point. I'm not clear on the issue yet but it does work most of the time.

Additionally, I was not able to update the demo scene as I could not open that in a recent version of Godot, so that will need to be fixed at some point as well.

A big improvement to the plugin would be to find a way to show the most recently selected point as opposed to the most recently changed point. I know Godot makes this difficult as there is no "selected_point" signal that is emitted from a Path3D node.

Looking forward to try and help improve the plugin, it's useful!